### PR TITLE
Mirror of mockito mockito#1723

### DIFF
--- a/src/main/java/org/mockito/internal/junit/ExceptionFactory.java
+++ b/src/main/java/org/mockito/internal/junit/ExceptionFactory.java
@@ -21,21 +21,23 @@ public class ExceptionFactory {
         ExceptionFactoryImpl theFactory = null;
 
         try {
+            Class.forName("org.opentest4j.AssertionFailedError");
             theFactory = new ExceptionFactoryImpl() {
                 @Override
                 public AssertionError create(String message, String wanted, String actual) {
                     return new org.mockito.exceptions.verification.opentest4j.ArgumentsAreDifferent(message, wanted, actual);
                 }
             };
-        } catch (Throwable onlyIfOpenTestIsNotAvailable) {
+        } catch (ClassNotFoundException onlyIfOpenTestIsNotAvailable) {
             try {
+                Class.forName("junit.framework.ComparisonFailure");
                 theFactory = new ExceptionFactoryImpl() {
                     @Override
                     public AssertionError create(String message, String wanted, String actual) {
                         return new org.mockito.exceptions.verification.junit.ArgumentsAreDifferent(message, wanted, actual);
                     }
                 };
-            } catch (Throwable onlyIfJUnitIsNotAvailable) {
+            } catch (ClassNotFoundException onlyIfJUnitIsNotAvailable) {
             }
         }
         factory = (theFactory == null) ? new ExceptionFactoryImpl() {


### PR DESCRIPTION
Mirror of mockito mockito#1723
The original implementation of conditional OpenTest4J support (#1667) relied on some implicit behaviour of the Java classloader to generate and catch the exception at the right time. It seems that this behaviour is not always exactly replicated in all environments - for example, in #1716, where Mockito was being used in an instrumentation test that was being run on an Android emulator.

The new implementation is a bit more direct in how it tests for the dependent classes. The existing test cases still pass, and <at>matejdro confirmed that this fixed his problem.

Fixes #1716.
