### PR TITLE
Mirror of mockito mockito#1732

### DIFF
--- a/src/main/java/org/mockito/BDDMockito.java
+++ b/src/main/java/org/mockito/BDDMockito.java
@@ -251,7 +251,9 @@ public class BDDMockito extends Mockito {
         /**
          * @see #verifyZeroInteractions(Object...)
          * @since 2.1.0
+         * @deprecated Since 2.x.x. Please migrate your code to {@link #shouldHaveNoInteractions()}
          */
+        @Deprecated
         void shouldHaveZeroInteractions();
 
         /**
@@ -259,6 +261,12 @@ public class BDDMockito extends Mockito {
          * @since 2.1.0
          */
         void shouldHaveNoMoreInteractions();
+
+        /**
+         * @see #verifyNoInteractions(Object...)
+         * @since 2.x.x
+         */
+        void shouldHaveNoInteractions();
     }
 
     private static class ThenImpl<T> implements Then<T> {
@@ -315,6 +323,14 @@ public class BDDMockito extends Mockito {
          */
         public void shouldHaveNoMoreInteractions() {
             verifyNoMoreInteractions(mock);
+        }
+
+        /**
+         * @see #verifyNoInteractions(Object...)
+         * @since 2.x.x
+         */
+        public void shouldHaveNoInteractions() {
+            verifyNoInteractions(mock);
         }
     }
 

--- a/src/main/java/org/mockito/Mockito.java
+++ b/src/main/java/org/mockito/Mockito.java
@@ -2249,9 +2249,31 @@ public class Mockito extends ArgumentMatchers {
      * This method has the same behavior as {@link #verifyNoMoreInteractions(Object...)}.
      *
      * @param mocks to be verified
+     * @deprecated Since 2.x.x. Please migrate your code to {@link #verifyNoInteractions(Object...)}
      */
+    @Deprecated
     public static void verifyZeroInteractions(Object... mocks) {
         MOCKITO_CORE.verifyNoMoreInteractions(mocks);
+    }
+
+    /**
+     * Verifies that no interactions happened on given mocks.
+     * <pre class="code"><code class="java">
+     *   verifyNoInteractions(mockOne, mockTwo);
+     * </code></pre>
+     * This method will also detect invocations
+     * that occurred before the test method, for example: in <code>setUp()</code>, <code>&#064;Before</code> method or in constructor.
+     * Consider writing nice code that makes interactions only in test methods.
+     * <p>
+     * See also {@link Mockito#never()} - it is more explicit and communicates the intent well.
+     * <p>
+     * See examples in javadoc for {@link Mockito} class
+     *
+     * @param mocks to be verified
+     * @since 2.x.x
+     */
+    public static void verifyNoInteractions(Object... mocks) {
+        MOCKITO_CORE.verifyNoInteractions(mocks);
     }
 
     /**

--- a/src/main/java/org/mockito/internal/MockitoCore.java
+++ b/src/main/java/org/mockito/internal/MockitoCore.java
@@ -43,6 +43,7 @@ import static org.mockito.internal.util.MockUtil.getMockHandler;
 import static org.mockito.internal.util.MockUtil.isMock;
 import static org.mockito.internal.util.MockUtil.resetMock;
 import static org.mockito.internal.util.MockUtil.typeMockabilityOf;
+import static org.mockito.internal.verification.VerificationModeFactory.noInteractions;
 import static org.mockito.internal.verification.VerificationModeFactory.noMoreInteractions;
 
 
@@ -129,6 +130,24 @@ public class MockitoCore {
                 assertNotStubOnlyMock(mock);
                 VerificationDataImpl data = new VerificationDataImpl(invocations, null);
                 noMoreInteractions().verify(data);
+            } catch (NotAMockException e) {
+                throw notAMockPassedToVerifyNoMoreInteractions();
+            }
+        }
+    }
+
+    public void verifyNoInteractions(Object... mocks) {
+        assertMocksNotEmpty(mocks);
+        mockingProgress().validateState();
+        for (Object mock : mocks) {
+            try {
+                if (mock == null) {
+                    throw nullPassedToVerifyNoMoreInteractions();
+                }
+                InvocationContainerImpl invocations = getInvocationContainer(mock);
+                assertNotStubOnlyMock(mock);
+                VerificationDataImpl data = new VerificationDataImpl(invocations, null);
+                noInteractions().verify(data);
             } catch (NotAMockException e) {
                 throw notAMockPassedToVerifyNoMoreInteractions();
             }

--- a/src/main/java/org/mockito/internal/exceptions/Reporter.java
+++ b/src/main/java/org/mockito/internal/exceptions/Reporter.java
@@ -176,7 +176,7 @@ public class Reporter {
                 "Method requires argument(s)!",
                 "Pass mocks that should be verified, e.g:",
                 "    verifyNoMoreInteractions(mockOne, mockTwo);",
-                "    verifyZeroInteractions(mockOne, mockTwo);",
+                "    verifyNoInteractions(mockOne, mockTwo);",
                 ""
         ));
     }
@@ -186,7 +186,7 @@ public class Reporter {
                 "Argument(s) passed is not a mock!",
                 "Examples of correct verifications:",
                 "    verifyNoMoreInteractions(mockOne, mockTwo);",
-                "    verifyZeroInteractions(mockOne, mockTwo);",
+                "    verifyNoInteractions(mockOne, mockTwo);",
                 ""
         ));
     }
@@ -196,7 +196,7 @@ public class Reporter {
                 "Argument(s) passed is null!",
                 "Examples of correct verifications:",
                 "    verifyNoMoreInteractions(mockOne, mockTwo);",
-                "    verifyZeroInteractions(mockOne, mockTwo);"
+                "    verifyNoInteractions(mockOne, mockTwo);"
         ));
     }
 
@@ -464,6 +464,23 @@ public class Reporter {
                 new LocationImpl(),
                 "But found this interaction on mock '" + MockUtil.getMockName(undesired.getMock()) + "':",
                 undesired.getLocation()
+        ));
+    }
+
+    public static MockitoAssertionError noInteractionsWanted(Object mock, List<VerificationAwareInvocation> invocations) {
+        ScenarioPrinter scenarioPrinter = new ScenarioPrinter();
+        String scenario = scenarioPrinter.print(invocations);
+
+        List<Location> locations = new ArrayList<Location>();
+        for (VerificationAwareInvocation invocation : invocations) {
+            locations.add(invocation.getLocation());
+        }
+        return new NoInteractionsWanted(join(
+            "No interactions wanted here:",
+            new LocationImpl(),
+            "But found these interactions on mock '" + MockUtil.getMockName(mock) + "':",
+            join("", locations),
+            scenario
         ));
     }
 

--- a/src/main/java/org/mockito/internal/verification/NoInteractions.java
+++ b/src/main/java/org/mockito/internal/verification/NoInteractions.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+
+package org.mockito.internal.verification;
+
+import org.mockito.internal.verification.api.VerificationData;
+import org.mockito.invocation.Invocation;
+import org.mockito.verification.VerificationMode;
+
+import java.util.List;
+
+import static org.mockito.internal.exceptions.Reporter.noInteractionsWanted;
+
+public class NoInteractions implements VerificationMode {
+
+    @SuppressWarnings("unchecked")
+    public void verify(VerificationData data) {
+        List<Invocation> invocations = data.getAllInvocations();
+        if (!invocations.isEmpty()) {
+            throw noInteractionsWanted(invocations.get(0).getMock(), (List) invocations);
+        }
+    }
+
+    @Override
+    public VerificationMode description(String description) {
+        return VerificationModeFactory.description(this, description);
+    }
+
+}

--- a/src/main/java/org/mockito/internal/verification/VerificationModeFactory.java
+++ b/src/main/java/org/mockito/internal/verification/VerificationModeFactory.java
@@ -33,6 +33,10 @@ public class VerificationModeFactory {
         return new NoMoreInteractions();
     }
 
+    public static NoInteractions noInteractions() {
+        return new NoInteractions();
+    }
+
     public static VerificationMode atMostOnce() {
         return atMost(1);
     }

--- a/src/test/java/org/mockito/MockitoTest.java
+++ b/src/test/java/org/mockito/MockitoTest.java
@@ -12,6 +12,7 @@ import static org.mockito.internal.progress.ThreadSafeMockingProgress.mockingPro
 import java.util.List;
 import org.junit.Test;
 import org.mockito.exceptions.misusing.NotAMockException;
+import org.mockito.exceptions.misusing.NullInsteadOfMockException;
 import org.mockito.internal.creation.MockSettingsImpl;
 
 @SuppressWarnings("unchecked")
@@ -45,6 +46,16 @@ public class MockitoTest {
     @Test(expected=NotAMockException.class)
     public void shouldValidateMockWhenVerifyingZeroInteractions() {
         Mockito.verifyZeroInteractions("notMock");
+    }
+
+    @Test(expected=NotAMockException.class)
+    public void shouldValidateMockWhenVerifyingNoInteractions() {
+        Mockito.verifyNoInteractions("notMock");
+    }
+
+    @Test(expected=NullInsteadOfMockException.class)
+    public void shouldValidateNullMockWhenVerifyingNoInteractions() {
+        Mockito.verifyNoInteractions(new Object[] { null });
     }
 
     @SuppressWarnings({"CheckReturnValue", "MockitoUsage"})

--- a/src/test/java/org/mockito/internal/InvalidStateDetectionTest.java
+++ b/src/test/java/org/mockito/internal/InvalidStateDetectionTest.java
@@ -68,6 +68,9 @@ public class InvalidStateDetectionTest extends TestBase {
         detectsAndCleansUp(new OnVerifyNoMoreInteractions(), UnfinishedStubbingException.class);
 
         when(mock.simpleMethod());
+        detectsAndCleansUp(new OnVerifyNoInteractions(), UnfinishedStubbingException.class);
+
+        when(mock.simpleMethod());
         detectsAndCleansUp(new OnDoAnswer(), UnfinishedStubbingException.class);
     }
 
@@ -93,6 +96,9 @@ public class InvalidStateDetectionTest extends TestBase {
         detectsAndCleansUp(new OnVerifyNoMoreInteractions(), UnfinishedStubbingException.class);
 
         doAnswer(null);
+        detectsAndCleansUp(new OnVerifyNoInteractions(), UnfinishedStubbingException.class);
+
+        doAnswer(null);
         detectsAndCleansUp(new OnDoAnswer(), UnfinishedStubbingException.class);
     }
 
@@ -115,6 +121,9 @@ public class InvalidStateDetectionTest extends TestBase {
         detectsAndCleansUp(new OnVerifyNoMoreInteractions(), UnfinishedVerificationException.class);
 
         verify(mock);
+        detectsAndCleansUp(new OnVerifyNoInteractions(), UnfinishedVerificationException.class);
+
+        verify(mock);
         detectsAndCleansUp(new OnDoAnswer(), UnfinishedVerificationException.class);
     }
 
@@ -131,6 +140,9 @@ public class InvalidStateDetectionTest extends TestBase {
 
         anyObject();
         detectsAndCleansUp(new OnVerifyNoMoreInteractions(), InvalidUseOfMatchersException.class);
+
+        anyObject();
+        detectsAndCleansUp(new OnVerifyNoInteractions(), InvalidUseOfMatchersException.class);
 
         anyObject();
         detectsAndCleansUp(new OnDoAnswer(), InvalidUseOfMatchersException.class);
@@ -195,6 +207,13 @@ public class InvalidStateDetectionTest extends TestBase {
         @SuppressWarnings({"CheckReturnValue", "MockitoUsage"})
         public void detect(IMethods mock) {
             verifyNoMoreInteractions(mock);
+        }
+    }
+
+    private static class OnVerifyNoInteractions implements DetectsInvalidState {
+        @SuppressWarnings({"CheckReturnValue", "MockitoUsage"})
+        public void detect(IMethods mock) {
+            verifyNoInteractions(mock);
         }
     }
 

--- a/src/test/java/org/mockito/internal/verification/NoInteractionsTest.java
+++ b/src/test/java/org/mockito/internal/verification/NoInteractionsTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2017 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.internal.verification;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import org.mockito.exceptions.verification.NoInteractionsWanted;
+import org.mockito.internal.creation.MockSettingsImpl;
+import org.mockito.internal.invocation.InvocationBuilder;
+import org.mockito.internal.invocation.InvocationMatcher;
+import org.mockito.internal.stubbing.InvocationContainerImpl;
+import org.mockitousage.IMethods;
+import org.mockitoutil.TestBase;
+
+import static junit.framework.TestCase.fail;
+import static org.mockito.Mockito.mock;
+
+public class NoInteractionsTest extends TestBase {
+
+    @Test
+    public void noInteractionsExceptionMessageShouldDescribeMock() {
+        //given
+        NoInteractions n = new NoInteractions();
+        IMethods mock = mock(IMethods.class, "a mock");
+        InvocationMatcher i = new InvocationBuilder().mock(mock).toInvocationMatcher();
+
+        InvocationContainerImpl invocations =
+            new InvocationContainerImpl(new MockSettingsImpl());
+        invocations.setInvocationForPotentialStubbing(i);
+
+        try {
+            //when
+            n.verify(new VerificationDataImpl(invocations, null));
+            //then
+            fail();
+        } catch (NoInteractionsWanted e) {
+            Assertions.assertThat(e.toString()).contains(mock.toString());
+        }
+    }
+
+}

--- a/src/test/java/org/mockitousage/basicapi/ResetTest.java
+++ b/src/test/java/org/mockitousage/basicapi/ResetTest.java
@@ -62,6 +62,13 @@ public class ResetTest extends TestBase {
     }
 
     @Test
+    public void shouldRemoveAllInteractionsVerifyNoInteractions() throws Exception {
+        mock.simpleMethod(1);
+        reset(mock);
+        verifyNoInteractions(mock);
+    }
+
+    @Test
     public void shouldRemoveStubbingToString() throws Exception {
         IMethods mockTwo = mock(IMethods.class);
         when(mockTwo.toString()).thenReturn("test");
@@ -75,6 +82,14 @@ public class ResetTest extends TestBase {
         doThrow(new RuntimeException()).when(mock).simpleMethod("two");
         reset(mock);
         verifyZeroInteractions(mock);
+    }
+
+    @Test
+    public void shouldStubbingNotBeTreatedAsInteractionVerifyNoInteractions() {
+        when(mock.simpleMethod("one")).thenThrow(new RuntimeException());
+        doThrow(new RuntimeException()).when(mock).simpleMethod("two");
+        reset(mock);
+        verifyNoInteractions(mock);
     }
 
     @Test

--- a/src/test/java/org/mockitousage/customization/BDDMockitoTest.java
+++ b/src/test/java/org/mockitousage/customization/BDDMockitoTest.java
@@ -269,6 +269,11 @@ public class BDDMockitoTest extends TestBase {
     }
 
     @Test
+    public void should_validate_that_mock_had_no_interactions() {
+        then(mock).shouldHaveNoInteractions();
+    }
+
+    @Test
     public void should_fail_when_mock_had_unwanted_interactions() {
         mock.booleanObjectReturningMethod();
 

--- a/src/test/java/org/mockitousage/misuse/InvalidUsageTest.java
+++ b/src/test/java/org/mockitousage/misuse/InvalidUsageTest.java
@@ -37,6 +37,11 @@ public class InvalidUsageTest extends TestBase {
         verifyZeroInteractions();
     }
 
+    @Test(expected=MockitoException.class)
+    public void shouldRequireArgumentsWhenVerifyingNoInteractions() {
+        verifyNoInteractions();
+    }
+
     @SuppressWarnings({"CheckReturnValue", "MockitoUsage"})
     @Test(expected=MockitoException.class)
     public void shouldNotCreateInOrderObjectWithoutMocks() {
@@ -107,6 +112,17 @@ public class InvalidUsageTest extends TestBase {
     }
 
     @Test
+    public void shouldNotMockObjectMethodsOnInterfaceVerifyNoInteractions() throws Exception {
+        ObjectLikeInterface inter = mock(ObjectLikeInterface.class);
+
+        inter.equals(null);
+        inter.toString();
+        inter.hashCode();
+
+        verifyNoInteractions(inter);
+    }
+
+    @Test
     public void shouldNotMockObjectMethodsOnClass() throws Exception {
         Object clazz = mock(ObjectLikeInterface.class);
 
@@ -115,5 +131,16 @@ public class InvalidUsageTest extends TestBase {
         clazz.hashCode();
 
         verifyZeroInteractions(clazz);
+    }
+
+    @Test
+    public void shouldNotMockObjectMethodsOnClassVerifyNoInteractions() throws Exception {
+        Object clazz = mock(ObjectLikeInterface.class);
+
+        clazz.equals(null);
+        clazz.toString();
+        clazz.hashCode();
+
+        verifyNoInteractions(clazz);
     }
 }

--- a/src/test/java/org/mockitousage/stacktrace/StackTraceFilteringTest.java
+++ b/src/test/java/org/mockitousage/stacktrace/StackTraceFilteringTest.java
@@ -21,6 +21,7 @@ import org.mockitoutil.TestBase;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
@@ -69,6 +70,17 @@ public class StackTraceFilteringTest extends TestBase {
             fail();
         } catch (NoInteractionsWanted e) {
             Assertions.assertThat(e).has(firstMethodInStackTrace("shouldFilterStackTraceOnVerifyZeroInteractions"));
+        }
+    }
+
+    @Test
+    public void shouldFilterStackTraceOnVerifyNoInteractions() {
+        mock.oneArg(true);
+        try {
+            verifyNoInteractions(mock);
+            fail();
+        } catch (NoInteractionsWanted e) {
+            Assertions.assertThat(e).has(firstMethodInStackTrace("shouldFilterStackTraceOnVerifyNoInteractions"));
         }
     }
 

--- a/src/test/java/org/mockitousage/stubbing/BasicStubbingTest.java
+++ b/src/test/java/org/mockitousage/stubbing/BasicStubbingTest.java
@@ -67,6 +67,14 @@ public class BasicStubbingTest extends TestBase {
     }
 
     @Test
+    public void should_stubbing_not_be_treated_as_interaction_verify_no_interactions() {
+        when(mock.simpleMethod("one")).thenThrow(new RuntimeException());
+        doThrow(new RuntimeException()).when(mock).simpleMethod("two");
+
+        verifyNoInteractions(mock);
+    }
+
+    @Test
     public void unfinished_stubbing_cleans_up_the_state() {
         reset(mock);
         try {
@@ -76,6 +84,18 @@ public class BasicStubbingTest extends TestBase {
 
         //anything that can cause state validation
         verifyZeroInteractions(mock);
+    }
+
+    @Test
+    public void unfinished_stubbing_cleans_up_the_state_verify_no_interactions() {
+        reset(mock);
+        try {
+            when("").thenReturn("");
+            fail();
+        } catch (MissingMethodInvocationException e) {}
+
+        //anything that can cause state validation
+        verifyNoInteractions(mock);
     }
 
     @Test

--- a/src/test/java/org/mockitousage/stubbing/StubbingWithThrowablesTest.java
+++ b/src/test/java/org/mockitousage/stubbing/StubbingWithThrowablesTest.java
@@ -13,8 +13,8 @@ import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
@@ -357,7 +357,7 @@ public class StubbingWithThrowablesTest extends TestBase {
         when(mock.size()).thenThrow(new RuntimeException());
         doThrow(new RuntimeException()).when(mock).clone();
 
-        verifyZeroInteractions(mock);
+        verifyNoInteractions(mock);
 
         mock.add("test");
 

--- a/src/test/java/org/mockitousage/verification/BasicVerificationInOrderTest.java
+++ b/src/test/java/org/mockitousage/verification/BasicVerificationInOrderTest.java
@@ -264,6 +264,11 @@ public class BasicVerificationInOrderTest extends TestBase {
         verifyZeroInteractions(mockOne);
     }
 
+    @Test(expected = NoInteractionsWanted.class)
+    public void shouldFailOnVerifyNoInteractions() {
+        verifyNoInteractions(mockOne);
+    }
+
     @SuppressWarnings({"all", "CheckReturnValue", "MockitoUsage"})
     @Test(expected = MockitoException.class)
     public void shouldScreamWhenNullPassed() {

--- a/src/test/java/org/mockitousage/verification/DescriptiveMessagesWhenVerificationFailsTest.java
+++ b/src/test/java/org/mockitousage/verification/DescriptiveMessagesWhenVerificationFailsTest.java
@@ -211,6 +211,33 @@ public class DescriptiveMessagesWhenVerificationFailsTest extends TestBase {
     }
 
     @Test
+    public void should_print_first_unexpected_invocation_when_verifying_no_interactions() {
+        mock.twoArgumentMethod(1, 2);
+        mock.threeArgumentMethod(1, "2", "3");
+
+        try {
+            verifyNoInteractions(mock);
+            fail();
+        } catch (NoInteractionsWanted e) {
+            String expected =
+                "\n" +
+                    "No interactions wanted here:" +
+                    "\n" +
+                    "-> at";
+
+            assertThat(e).hasMessageContaining(expected);
+
+            String expectedCause =
+                "\n" +
+                    "But found these interactions on mock '" + mock + "':" +
+                    "\n" +
+                    "-> at";
+
+            assertThat(e).hasMessageContaining(expectedCause);
+        }
+    }
+
+    @Test
     public void should_print_method_name_when_verifying_at_least_once() throws Exception {
         try {
             verify(mock, atLeastOnce()).twoArgumentMethod(1, 2);

--- a/src/test/java/org/mockitousage/verification/NoMoreInteractionsVerificationTest.java
+++ b/src/test/java/org/mockitousage/verification/NoMoreInteractionsVerificationTest.java
@@ -58,6 +58,9 @@ public class NoMoreInteractionsVerificationTest extends TestBase {
 
         verifyZeroInteractions(mock);
         verifyZeroInteractions(mock);
+
+        verifyNoInteractions(mock);
+        verifyNoInteractions(mock);
     }
 
     @Test
@@ -76,6 +79,16 @@ public class NoMoreInteractionsVerificationTest extends TestBase {
 
         try {
             verifyNoMoreInteractions(mock);
+            fail();
+        } catch (NoInteractionsWanted e) {}
+    }
+
+    @Test
+    public void shouldFailNoInteractionsVerification() throws Exception {
+        mock.clear();
+
+        try {
+            verifyNoInteractions(mock);
             fail();
         } catch (NoInteractionsWanted e) {}
     }
@@ -122,6 +135,25 @@ public class NoMoreInteractionsVerificationTest extends TestBase {
         verifyNoMoreInteractions(list);
         try {
             verifyZeroInteractions(map);
+            fail();
+        } catch (NoInteractionsWanted e) {}
+    }
+
+    @Test
+    public void shouldVerifyOneMockButFailOnOtherVerifyNoInteractions() throws Exception {
+        List<String> list = mock(List.class);
+        Map<String, Integer> map = mock(Map.class);
+
+        list.add("one");
+        list.add("one");
+
+        map.put("one", 1);
+
+        verify(list, times(2)).add("one");
+
+        verifyNoMoreInteractions(list);
+        try {
+            verifyNoInteractions(map);
             fail();
         } catch (NoInteractionsWanted e) {}
     }

--- a/src/test/java/org/mockitousage/verification/VerificationOnMultipleMocksUsingMatchersTest.java
+++ b/src/test/java/org/mockitousage/verification/VerificationOnMultipleMocksUsingMatchersTest.java
@@ -60,5 +60,6 @@ public class VerificationOnMultipleMocksUsingMatchersTest extends TestBase {
 
         verifyNoMoreInteractions(list, map);
         verifyZeroInteractions(set);
+        verifyNoInteractions(set);
     }
 }


### PR DESCRIPTION
Mirror of mockito mockito#1732
With #995 I provided a fix to #977 and #989
However that PR targeted `master`, which eventually became `old-3.x`, and its code didn't make it into `release/3.x`.
#977 and #989 should be reopened.

I have back-ported that PR to target `release/2.x`.
`verifyZeroInteractions` is marked as `<at>Deprecated` and a new `verifyNoInteractions` is added. There are no breaking changes AFAIK, so this code is backwards compatible.
Since I don't know if/when this code will ship, javadocs contain a placeholder `Since 2.x.x`
